### PR TITLE
Check extensions during validation & update

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ This example would output (as a string):
 
 ### CBV attributes autocomplete
 
-The latest version of the SDK enables you to easily search among all attributes of each Core Business Vocabulary.
-In order to do this, for example, you can import `cbv` as we did in the script above.
+The SDK enables you to easily search among all attributes of each Core Business Vocabulary.
+In order to do this, you need to import `cbv` as we did in the script above.
 Then, by typing `cbv.actionType.` as a parameter of the `setAction` method of the `ObjectEvent` class, you will be displayed
 all the attributes associated to this particular CBV.
 The list of all CBVs and the respective attributes can be viewed in ./src/cbv/cbv.js.

--- a/example/node_example/example_with_full_possibility.js
+++ b/example/node_example/example_with_full_possibility.js
@@ -25,6 +25,21 @@ const {
     cbv 
   } = require('epcis2.js');
 
+  // you can override the global parameters with the setup function
+setup({
+  apiUrl: 'https://api.evrythng.io/v2/epcis/',
+  headers: {
+    'content-type': 'application/json',
+    authorization: 'MY_API_KEY',
+  },
+  eventTimeZoneOffset: '-02:00',
+  timeout: '3000',
+  EPCISDocumentContext: 'https://id.gs1.org/epcis-context.jsonld',
+  EPCISDocumentSchemaVersion: '2.0',
+  documentValidation: true,
+  validationMode: 'fast' //'full' otherwise
+});
+
 const buildSensorReportElementExample = () => {
   //sensor report element
   return new SensorReportElement().setType(cbv.sensorMeasurementTypes.temperature)
@@ -158,6 +173,7 @@ const buildObjectEvent = () => {
   .setPersistentDisposition(buildPersistentDispositionExample())
   .setIlmd(buildIlmdExample())
   .addExtension('example:myField', 'my_custom_value')
+  .setCertificationInfo('https://accreditation-council.example.org/certificate/ABC12345')
   .generateHashID({
     example: 'http://ns.example.com/epcis/',
     ext1: 'http://example.com/ext1/'
@@ -170,6 +186,7 @@ const buildAssociationEvent = () => {
     "type": "AssociationEvent",
     "eventTime": "2019-11-01T13:00:00.000Z",
     "recordTime": "2005-04-05T02:33:31.116Z",
+    "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
     "eventID":"ni:///sha-256;36abb3a2c0a726de32ac4beafd6b8bc4ba0b1d2de244490312e5cbec7b5ddece?ver=CBV2.0",
     "eventTimeZoneOffset": "+01:00",
     "parentID": "urn:epc:id:grai:4012345.55555.987",
@@ -363,7 +380,7 @@ const buildAssociationEvent = () => {
 
 const buildExtendedEvent = () => {
   return new ExtendedEvent().setType('My:custom:event:type')
-  .setEventID('ni:///sha-256;36abb3a2c0a726de32ac4beafd6b8bc4ba0b1d2de244490312e5cbec7b5ddece?ver=CBV2.0')
+  .generateHashID()
   .setEventTime("2005-04-05T02:33:31.116Z")
   .setRecordTime(new Date().toISOString());
 }
@@ -450,29 +467,19 @@ const buildEPCISHeaderExample = () => {
   return new EPCISHeader().setEPCISMasterData(buildEPCISMasterDataExample());
 }
 
-// you can override the global parameters with the setup function
-setup({
-  apiUrl: 'https://api.evrythng.io/v2/epcis/',
-  headers: {
-    'content-type': 'application/json',
-    authorization: 'MY_API_KEY',
-  },
-  eventTimeZoneOffset: '-02:00',
-  timeout: '1000',
-  EPCISDocumentContext: 'https://id.gs1.org/epcis-context.jsonld',
-  EPCISDocumentSchemaVersion: '2.0',
-  documentValidation: true,
-  validationMode: 'fast' //'full' otherwise
-});
 const sendACaptureRequestExample = async () => {
   try {
     const epcisDocument = new EPCISDocument();
     // epcisDocument
-    epcisDocument.setContext('https://gs1.github.io/EPCIS/epcis-context.jsonld')
+    epcisDocument.setContext(['https://gs1.github.io/EPCIS/epcis-context.jsonld',{
+      example: 'http://ns.example.com/epcis/',
+      ext1: 'http://example.com/ext1/'
+    }])
     .setCreationDate('2013-06-04T14:59:02.099+02:00')
     .setSchemaVersion('2.0')
     .setSender('urn:epc:id:sgln:0353579.00001.0')
     .setReceiver('urn:epc:id:sgln:5012345.00001.0')
+    .setId('test:documentId' + Math.floor(Math.random() * 9))
     .setInstanceIdentifier('1234567890')
     .setEPCISHeader(buildEPCISHeaderExample())
     .addEvent(buildAssociationEvent())

--- a/example/node_example/example_with_full_possibility_result.json
+++ b/example/node_example/example_with_full_possibility_result.json
@@ -1,10 +1,17 @@
 {
    "type":"EPCISDocument",
-   "@context":"https://gs1.github.io/EPCIS/epcis-context.jsonld",
+   "@context":[
+      "https://gs1.github.io/EPCIS/epcis-context.jsonld",
+      {
+         "example":"http://ns.example.com/epcis/",
+         "ext1":"http://example.com/ext1/"
+      }
+   ],
    "schemaVersion":"2.0",
    "creationDate":"2013-06-04T14:59:02.099+02:00",
    "sender":"urn:epc:id:sgln:0353579.00001.0",
    "receiver":"urn:epc:id:sgln:5012345.00001.0",
+   "id":"test:documentId1",
    "instanceIdentifier":"1234567890",
    "epcisHeader":{
       "epcisMasterData":{
@@ -125,6 +132,7 @@
             "type":"AssociationEvent",
             "eventTime":"2019-11-01T13:00:00.000Z",
             "recordTime":"2005-04-05T02:33:31.116Z",
+            "certificationInfo":"https://accreditation-council.example.org/certificate/ABC12345",
             "eventID":"ni:///sha-256;36abb3a2c0a726de32ac4beafd6b8bc4ba0b1d2de244490312e5cbec7b5ddece?ver=CBV2.0",
             "eventTimeZoneOffset":"-02:00",
             "parentID":"urn:epc:id:grai:4012345.55555.987",
@@ -342,7 +350,7 @@
             "bizStep":"receiving",
             "disposition":"in_progress",
             "errorDeclaration":{
-               "declarationTime":"2022-04-21T09:19:10.165Z",
+               "declarationTime":"2022-05-04T12:00:55.484Z",
                "reason":"incorrect_data",
                "example:vendorExtension":"Test1",
                "correctiveEventIDs":[
@@ -350,7 +358,7 @@
                ]
             },
             "readPoint":{
-               "id":"urn:epc:id:sgln:0012345.11111.603"
+               "id":"urn:epc:id:sgln:0012345.11111.159"
             },
             "bizLocation":{
                "id":"urn:epc:id:sgln:0012345.11111.2"
@@ -358,46 +366,46 @@
             "bizTransactionList":[
                {
                   "type":"po",
-                  "bizTransaction":"urn:epc:id:gdti:0614141.00001.1618142"
+                  "bizTransaction":"urn:epc:id:gdti:0614141.00001.1618647"
                },
                {
                   "type":"po",
-                  "bizTransaction":"urn:epc:id:gdti:0614141.00001.1618562"
+                  "bizTransaction":"urn:epc:id:gdti:0614141.00001.1618331"
                },
                {
                   "type":"po",
-                  "bizTransaction":"urn:epc:id:gdti:0614141.00001.1618385"
+                  "bizTransaction":"urn:epc:id:gdti:0614141.00001.161861"
                }
             ],
             "quantityList":[
                {
                   "epcClass":"urn:epc:class:lgtin:4012345.012345.9911111",
-                  "quantity":993,
+                  "quantity":47,
                   "uom":"KGM"
                },
                {
                   "epcClass":"urn:epc:class:lgtin:4012345.012345.9911111",
-                  "quantity":108,
+                  "quantity":168,
                   "uom":"KGM"
                },
                {
                   "epcClass":"urn:epc:class:lgtin:4012345.012345.9911111",
-                  "quantity":532,
+                  "quantity":500,
                   "uom":"KGM"
                }
             ],
             "sourceList":[
                {
                   "type":"location",
-                  "source":"urn:epc:id:sgln:4012345.00225.8"
-               },
-               {
-                  "type":"location",
                   "source":"urn:epc:id:sgln:4012345.00225.3"
                },
                {
                   "type":"location",
-                  "source":"urn:epc:id:sgln:4012345.00225.2"
+                  "source":"urn:epc:id:sgln:4012345.00225.6"
+               },
+               {
+                  "type":"location",
+                  "source":"urn:epc:id:sgln:4012345.00225.4"
                }
             ],
             "destinationList":[
@@ -417,7 +425,7 @@
             "sensorElementList":[
                {
                   "sensorMetadata":{
-                     "time":"2022-04-21T09:19:10.165Z",
+                     "time":"2022-05-04T12:00:55.483Z",
                      "deviceID":"urn:epc:id:giai:4000001.111",
                      "deviceMetadata":"https://id.gs1.org/giai/4000001111",
                      "rawData":"https://example.org/giai/401234599999",
@@ -430,7 +438,7 @@
                   "sensorReport":[
                      {
                         "type":"Temperature",
-                        "deviceID":"urn:epc:id:giai:4000001.564",
+                        "deviceID":"urn:epc:id:giai:4000001.108",
                         "rawData":"https://example.org/giai/401234599999",
                         "dataProcessingMethod":"https://example.com/gdti/4012345000054987",
                         "time":"2019-07-19T13:00:00.000Z",
@@ -455,7 +463,7 @@
                      },
                      {
                         "type":"Temperature",
-                        "deviceID":"urn:epc:id:giai:4000001.478",
+                        "deviceID":"urn:epc:id:giai:4000001.537",
                         "rawData":"https://example.org/giai/401234599999",
                         "dataProcessingMethod":"https://example.com/gdti/4012345000054987",
                         "time":"2019-07-19T13:00:00.000Z",
@@ -480,7 +488,7 @@
                      },
                      {
                         "type":"Temperature",
-                        "deviceID":"urn:epc:id:giai:4000001.791",
+                        "deviceID":"urn:epc:id:giai:4000001.60",
                         "rawData":"https://example.org/giai/401234599999",
                         "dataProcessingMethod":"https://example.com/gdti/4012345000054987",
                         "time":"2019-07-19T13:00:00.000Z",
@@ -508,7 +516,7 @@
                },
                {
                   "sensorMetadata":{
-                     "time":"2022-04-21T09:19:10.165Z",
+                     "time":"2022-05-04T12:00:55.484Z",
                      "deviceID":"urn:epc:id:giai:4000001.111",
                      "deviceMetadata":"https://id.gs1.org/giai/4000001111",
                      "rawData":"https://example.org/giai/401234599999",
@@ -519,56 +527,6 @@
                      "example:someFurtherMetadata":"someText"
                   },
                   "sensorReport":[
-                     {
-                        "type":"Temperature",
-                        "deviceID":"urn:epc:id:giai:4000001.895",
-                        "rawData":"https://example.org/giai/401234599999",
-                        "dataProcessingMethod":"https://example.com/gdti/4012345000054987",
-                        "time":"2019-07-19T13:00:00.000Z",
-                        "microorganism":"https://www.ncbi.nlm.nih.gov/taxonomy/1126011",
-                        "chemicalSubstance":"https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N",
-                        "value":26,
-                        "component":"x",
-                        "stringValue":"SomeString",
-                        "booleanValue":true,
-                        "hexBinaryValue":"f0f0f0",
-                        "uriValue":"https://id.gs1.org/giai/4000001111",
-                        "minValue":26,
-                        "maxValue":26.2,
-                        "meanValue":13.2,
-                        "percRank":50,
-                        "percValue":12.7,
-                        "uom":"CEL",
-                        "sDev":0.1,
-                        "deviceMetadata":"https://id.gs1.org/giai/4000001111",
-                        "example:someFurtherMetadata":"someText",
-                        "bizRules":"https://example.com/gdti/4012345000054987"
-                     },
-                     {
-                        "type":"Temperature",
-                        "deviceID":"urn:epc:id:giai:4000001.493",
-                        "rawData":"https://example.org/giai/401234599999",
-                        "dataProcessingMethod":"https://example.com/gdti/4012345000054987",
-                        "time":"2019-07-19T13:00:00.000Z",
-                        "microorganism":"https://www.ncbi.nlm.nih.gov/taxonomy/1126011",
-                        "chemicalSubstance":"https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N",
-                        "value":26,
-                        "component":"x",
-                        "stringValue":"SomeString",
-                        "booleanValue":true,
-                        "hexBinaryValue":"f0f0f0",
-                        "uriValue":"https://id.gs1.org/giai/4000001111",
-                        "minValue":26,
-                        "maxValue":26.2,
-                        "meanValue":13.2,
-                        "percRank":50,
-                        "percValue":12.7,
-                        "uom":"CEL",
-                        "sDev":0.1,
-                        "deviceMetadata":"https://id.gs1.org/giai/4000001111",
-                        "example:someFurtherMetadata":"someText",
-                        "bizRules":"https://example.com/gdti/4012345000054987"
-                     },
                      {
                         "type":"Temperature",
                         "deviceID":"urn:epc:id:giai:4000001.475",
@@ -593,13 +551,63 @@
                         "deviceMetadata":"https://id.gs1.org/giai/4000001111",
                         "example:someFurtherMetadata":"someText",
                         "bizRules":"https://example.com/gdti/4012345000054987"
+                     },
+                     {
+                        "type":"Temperature",
+                        "deviceID":"urn:epc:id:giai:4000001.263",
+                        "rawData":"https://example.org/giai/401234599999",
+                        "dataProcessingMethod":"https://example.com/gdti/4012345000054987",
+                        "time":"2019-07-19T13:00:00.000Z",
+                        "microorganism":"https://www.ncbi.nlm.nih.gov/taxonomy/1126011",
+                        "chemicalSubstance":"https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N",
+                        "value":26,
+                        "component":"x",
+                        "stringValue":"SomeString",
+                        "booleanValue":true,
+                        "hexBinaryValue":"f0f0f0",
+                        "uriValue":"https://id.gs1.org/giai/4000001111",
+                        "minValue":26,
+                        "maxValue":26.2,
+                        "meanValue":13.2,
+                        "percRank":50,
+                        "percValue":12.7,
+                        "uom":"CEL",
+                        "sDev":0.1,
+                        "deviceMetadata":"https://id.gs1.org/giai/4000001111",
+                        "example:someFurtherMetadata":"someText",
+                        "bizRules":"https://example.com/gdti/4012345000054987"
+                     },
+                     {
+                        "type":"Temperature",
+                        "deviceID":"urn:epc:id:giai:4000001.648",
+                        "rawData":"https://example.org/giai/401234599999",
+                        "dataProcessingMethod":"https://example.com/gdti/4012345000054987",
+                        "time":"2019-07-19T13:00:00.000Z",
+                        "microorganism":"https://www.ncbi.nlm.nih.gov/taxonomy/1126011",
+                        "chemicalSubstance":"https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N",
+                        "value":26,
+                        "component":"x",
+                        "stringValue":"SomeString",
+                        "booleanValue":true,
+                        "hexBinaryValue":"f0f0f0",
+                        "uriValue":"https://id.gs1.org/giai/4000001111",
+                        "minValue":26,
+                        "maxValue":26.2,
+                        "meanValue":13.2,
+                        "percRank":50,
+                        "percValue":12.7,
+                        "uom":"CEL",
+                        "sDev":0.1,
+                        "deviceMetadata":"https://id.gs1.org/giai/4000001111",
+                        "example:someFurtherMetadata":"someText",
+                        "bizRules":"https://example.com/gdti/4012345000054987"
                      }
                   ],
                   "example:myField":"my_custom_value"
                },
                {
                   "sensorMetadata":{
-                     "time":"2022-04-21T09:19:10.166Z",
+                     "time":"2022-05-04T12:00:55.484Z",
                      "deviceID":"urn:epc:id:giai:4000001.111",
                      "deviceMetadata":"https://id.gs1.org/giai/4000001111",
                      "rawData":"https://example.org/giai/401234599999",
@@ -612,7 +620,7 @@
                   "sensorReport":[
                      {
                         "type":"Temperature",
-                        "deviceID":"urn:epc:id:giai:4000001.840",
+                        "deviceID":"urn:epc:id:giai:4000001.320",
                         "rawData":"https://example.org/giai/401234599999",
                         "dataProcessingMethod":"https://example.com/gdti/4012345000054987",
                         "time":"2019-07-19T13:00:00.000Z",
@@ -637,7 +645,7 @@
                      },
                      {
                         "type":"Temperature",
-                        "deviceID":"urn:epc:id:giai:4000001.927",
+                        "deviceID":"urn:epc:id:giai:4000001.80",
                         "rawData":"https://example.org/giai/401234599999",
                         "dataProcessingMethod":"https://example.com/gdti/4012345000054987",
                         "time":"2019-07-19T13:00:00.000Z",
@@ -662,7 +670,7 @@
                      },
                      {
                         "type":"Temperature",
-                        "deviceID":"urn:epc:id:giai:4000001.849",
+                        "deviceID":"urn:epc:id:giai:4000001.311",
                         "rawData":"https://example.org/giai/401234599999",
                         "dataProcessingMethod":"https://example.com/gdti/4012345000054987",
                         "time":"2019-07-19T13:00:00.000Z",
@@ -699,17 +707,18 @@
             },
             "ilmd":{
                "ext1:boolean":"true",
-               "ext1:value":8
+               "ext1:value":0
             },
             "example:myField":"my_custom_value",
-            "eventID":"ni:///sha-256;919d713c3f791f5502edd258e233d1be690008dbfd39be2c977af30c2ef0b1ca?ver=CBV2.0"
+            "certificationInfo":"https://accreditation-council.example.org/certificate/ABC12345",
+            "eventID":"ni:///sha-256;dcedc78a072e1ad069aa8601f24c9c57091717e5e3e9fb909fb4c2fc481790ba?ver=CBV2.0"
          },
          {
             "eventTimeZoneOffset":"-02:00",
             "eventTime":"2005-04-05T02:33:31.116Z",
             "type":"My:custom:event:type",
-            "eventID":"ni:///sha-256;36abb3a2c0a726de32ac4beafd6b8bc4ba0b1d2de244490312e5cbec7b5ddece?ver=CBV2.0",
-            "recordTime":"2022-04-21T09:19:10.180Z"
+            "eventID":"ni:///sha-256;70b631edc102365e678929b8a49ba321d7d4f4a57e5d6356226d3c982e50cfb6?ver=CBV2.0",
+            "recordTime":"2022-05-04T12:00:55.497Z"
          }
       ]
    }

--- a/src/entity/epcis/EPCISDocument.js
+++ b/src/entity/epcis/EPCISDocument.js
@@ -251,6 +251,23 @@ export default class EPCISDocument extends Entity {
   }
 
   /**
+   * Set the id property
+   * @param {string} id
+   * @return {EPCISDocument} - the epcisDocument instance
+   */
+  setId(id) {
+    return this.generateSetterFunction('id', id, ['string']);
+  }
+
+  /**
+     * Getter for the id property
+     * @return {string} - the id
+     */
+  getId() {
+    return this.id;
+  }
+
+  /**
    * Check if the EPCISDocument respects the rules of the standard defined in
    * src/schema/EPCISDocument.schema.json
    * @return {boolean} - true if the EPCIS document is valid

--- a/src/schema/definitions.json
+++ b/src/schema/definitions.json
@@ -54,6 +54,19 @@
       "type": "string",
       "pattern": "^[A-Z0-9]{2,3}$"
     },
+    "certificationInfo": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/uri"
+          }
+        },
+        {
+          "$ref": "#/definitions/uri"
+        }
+      ]
+    },
     "eventID": {
       "$ref": "#/definitions/uri"
     },
@@ -514,7 +527,8 @@
             "recordTime",
             "eventTimeZoneOffset",
             "eventID",
-            "errorDeclaration"
+            "errorDeclaration",
+            "certificationInfo"
           ]
         },
         {

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -30,7 +30,7 @@ const ajv = addFormats(
 
 /**
  * This function returns a list of all the extensions defined in the context.
- * @param {{}} epcisDocument - the EPCISDocument that we want to get extensions from the context
+ * @param {{}} epcisDocument - the EPCISDocument containing the extensions' context.
  * @returns an array of all the extensions that are in the context
  */
 export const getAuthorizedExtensions = (epcisDocument) => {
@@ -39,24 +39,14 @@ export const getAuthorizedExtensions = (epcisDocument) => {
     epcisDocumentContext = epcisDocument['@context'];
 
     let contextObject = {};
-    let i = 0;
     if (Array.isArray(epcisDocumentContext)) {
       epcisDocumentContext.forEach((c) => {
-        if (typeof c === 'string') {
-          /* We must transform the string into an object.
-            For this we put the name of the field: default
-            and we have a counter in the case that there are
-            several strings in the array */
-          const obj = {};
-          i += 1;
-          obj[`default${i > 1 ? i : ''}`] = c;
-          contextObject = { ...contextObject, ...obj };
-        } else if (c instanceof Object) {
+        if (c instanceof Object) {
           contextObject = { ...contextObject, ...c };
         }
       });
     } else if (typeof epcisDocumentContext === 'string') {
-      contextObject = { default: epcisDocumentContext };
+      return [];
     } else if (epcisDocumentContext instanceof Object) {
       contextObject = epcisDocumentContext;
     }

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -27,6 +27,43 @@ const successResult = { success: true, errors: [] };
 const ajv = addFormats(new Ajv({ useDefaults: true, strict: false }), { mode: validationMode });
 
 /**
+ * This function returns a list of all the extensions defined in the context.
+ * @param {{}} epcisDocument - the EPCISDocument that we want to get extensions from the context
+ * @returns an array of all the extensions that are in the context
+ */
+const getAuthorizedExtensions = (epcisDocument) => {
+  let epcisDocumentContext = {};
+  if (Object.keys(epcisDocument).includes('@context')) {
+    epcisDocumentContext = epcisDocument['@context'];
+
+    let contextObject = {};
+    let i = 0;
+    if (Array.isArray(epcisDocumentContext)) {
+      epcisDocumentContext.forEach((c) => {
+        if (typeof c === 'string') {
+          /* We must transform the string into an object.
+            For this we put the name of the field: default
+            and we have a counter in the case that there are
+            several strings in the array */
+          const obj = {};
+          i += 1;
+          obj[`default${i > 1 ? i : ''}`] = c;
+          contextObject = { ...contextObject, ...obj };
+        } else if (c instanceof Object) {
+          contextObject = { ...contextObject, ...c };
+        }
+      });
+    } else if (typeof epcisDocumentContext === 'string') {
+      contextObject = { default: epcisDocumentContext };
+    } else if (epcisDocumentContext instanceof Object) {
+      contextObject = epcisDocumentContext;
+    }
+    return Object.keys(contextObject);
+  }
+  return [];
+};
+
+/**
  * Load a schema and include 'definitions'.
  *
  * @param {object} schema - schema to be loaded.
@@ -150,6 +187,17 @@ const validateExtraEventFields = (event) => {
   }
 };
 
+const checkExtensions = (extensions, authorizedExtensions) => {
+  for (let k = 0; k < extensions.length; k += 1) {
+    const extension = extensions[k];
+    if (!authorizedExtensions.includes(extension)) {
+      const error = `Event contains unknown extension: ${extension}`;
+      return { success: false, errors: [error] };
+    }
+  }
+  return successResult;
+};
+
 /**
  * Validate EPCIS Document.
  *
@@ -189,6 +237,41 @@ export const validateEpcisDocument = (epcisDocument, throwError = true) => {
       return eventFieldsResult;
     }
   }
+
+  const authorizedExtensions = getAuthorizedExtensions(epcisDocument);
+
+  // for each event in the eventList find all the extensions
+  for (let i = 0; i < eventList.length; i += 1) {
+    const event = eventList[i];
+    const eventCustomFields = Object.keys(event).filter((key) => key.includes(':'));
+    const eventExtensions = eventCustomFields.map((key) => key.split(':')[0]);
+
+    // check if the extensions are authorized for the event fields
+    const eventExtensionsResult = checkExtensions(eventExtensions, authorizedExtensions);
+    if (!eventExtensionsResult.success && throwError) {
+      throw new Error(`${eventExtensionsResult.errors}`);
+    } else if (!eventExtensionsResult.success) {
+      return eventExtensionsResult;
+    }
+
+    // check if the extensions are authorized for the sub-event fields (e.g. sensorElementList)
+    const eventFields = Object.keys(event);
+    for (let j = 0; j < eventFields.length; j += 1) {
+      if (!eventFields[j].includes(':') && typeof event[eventFields[j]] === 'object') {
+        const eventSubFields = Object.keys(event[eventFields[j]]);
+        const customFields = eventSubFields.filter((key) => key.includes(':'));
+        const extensions = customFields.map((key) => key.split(':')[0]);
+
+        const extensionsResult = checkExtensions(extensions, authorizedExtensions);
+        if (!extensionsResult.success && throwError) {
+          throw new Error(`${extensionsResult.errors}`);
+        } else if (!extensionsResult.success) {
+          return extensionsResult;
+        }
+      }
+    }
+  }
+
   // No errors in document or any events
   return successResult;
 };

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -24,14 +24,16 @@ import ExtendedEvent from './ExtendedEvent.schema.json';
  */
 const successResult = { success: true, errors: [] };
 
-const ajv = addFormats(new Ajv({ useDefaults: true, strict: false }), { mode: settings.validationMode });
+const ajv = addFormats(
+  new Ajv({ useDefaults: true, strict: false }), { mode: settings.validationMode },
+);
 
 /**
  * This function returns a list of all the extensions defined in the context.
  * @param {{}} epcisDocument - the EPCISDocument that we want to get extensions from the context
  * @returns an array of all the extensions that are in the context
  */
-const getAuthorizedExtensions = (epcisDocument) => {
+export const getAuthorizedExtensions = (epcisDocument) => {
   let epcisDocumentContext = {};
   if (Object.keys(epcisDocument).includes('@context')) {
     epcisDocumentContext = epcisDocument['@context'];
@@ -187,7 +189,7 @@ const validateExtraEventFields = (event) => {
   }
 };
 
-const checkIfExtensionsAreDefinedInTheContext = (extensions, authorizedExtensions) => {
+export const checkIfExtensionsAreDefinedInTheContext = (extensions, authorizedExtensions) => {
   for (let k = 0; k < extensions.length; k += 1) {
     const extension = extensions[k];
     if (!authorizedExtensions.includes(extension)) {
@@ -238,7 +240,7 @@ export const validateEpcisDocument = (epcisDocument, throwError = true) => {
     }
   }
 
-  if(settings.checkExtensions) { 
+  if (settings.checkExtensions) {
     const authorizedExtensions = getAuthorizedExtensions(epcisDocument);
 
     // for each event in the eventList find all the extensions
@@ -246,15 +248,18 @@ export const validateEpcisDocument = (epcisDocument, throwError = true) => {
       const event = eventList[i];
       const eventCustomFields = Object.keys(event).filter((key) => key.includes(':'));
       const eventExtensions = eventCustomFields.map((key) => key.split(':')[0]);
-  
+
       // check if the extensions are authorized for the event fields
-      const eventExtensionsResult = checkIfExtensionsAreDefinedInTheContext(eventExtensions, authorizedExtensions);
+      const eventExtensionsResult = checkIfExtensionsAreDefinedInTheContext(
+        eventExtensions,
+        authorizedExtensions,
+      );
       if (!eventExtensionsResult.success && throwError) {
         throw new Error(`${eventExtensionsResult.errors}`);
       } else if (!eventExtensionsResult.success) {
         return eventExtensionsResult;
       }
-  
+
       // check if the extensions are authorized for the sub-event fields (e.g. sensorElementList)
       const eventFields = Object.keys(event);
       for (let j = 0; j < eventFields.length; j += 1) {
@@ -262,8 +267,10 @@ export const validateEpcisDocument = (epcisDocument, throwError = true) => {
           const eventSubFields = Object.keys(event[eventFields[j]]);
           const customFields = eventSubFields.filter((key) => key.includes(':'));
           const extensions = customFields.map((key) => key.split(':')[0]);
-  
-          const extensionsResult = checkIfExtensionsAreDefinedInTheContext(extensions, authorizedExtensions);
+          const extensionsResult = checkIfExtensionsAreDefinedInTheContext(
+            extensions,
+            authorizedExtensions,
+          );
           if (!extensionsResult.success && throwError) {
             throw new Error(`${extensionsResult.errors}`);
           } else if (!extensionsResult.success) {
@@ -273,7 +280,6 @@ export const validateEpcisDocument = (epcisDocument, throwError = true) => {
       }
     }
   }
-  
 
   // No errors in document or any events
   return successResult;

--- a/src/settings.js
+++ b/src/settings.js
@@ -23,6 +23,8 @@
  * @property {string} validationMode - The default value of 'validationMode' for the
  * validation of an EPCISDocument or an EPCIS Event against schemas.
  * Possible values are either "full" or "fast".
+ * @property {boolean} checkExtensions - if true, the extension of the EPCISDocument will be
+ * checked against the EPCIS Document context. Otherwise, the extensions checks will be ignored.
  * Please refer to: https://www.npmjs.com/package/ajv-formats/v/0.3.4
  */
 
@@ -42,6 +44,7 @@ export const defaultSettings = {
   EPCISDocumentSchemaVersion: '2.0',
   documentValidation: true,
   validationMode: 'full',
+  checkExtensions: true,
 };
 
 // Initialize settings with defaults.

--- a/src/settings.js
+++ b/src/settings.js
@@ -25,7 +25,7 @@
  * Possible values are either "full" or "fast".
  * @property {boolean} checkExtensions - set it to true if you want the extension of the
  * EPCISDocument to be checked against the EPCIS Document context.
- * Otherwise, the extensions checks will be ignored.
+ * Otherwise, the extensions check will be ignored.
  * Please refer to: https://www.npmjs.com/package/ajv-formats/v/0.3.4
  */
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -23,8 +23,9 @@
  * @property {string} validationMode - The default value of 'validationMode' for the
  * validation of an EPCISDocument or an EPCIS Event against schemas.
  * Possible values are either "full" or "fast".
- * @property {boolean} checkExtensions - if true, the extension of the EPCISDocument will be
- * checked against the EPCIS Document context. Otherwise, the extensions checks will be ignored.
+ * @property {boolean} checkExtensions - set it to true if you want the extension of the
+ * EPCISDocument to be checked against the EPCIS Document context.
+ * Otherwise, the extensions checks will be ignored.
  * Please refer to: https://www.npmjs.com/package/ajv-formats/v/0.3.4
  */
 
@@ -44,7 +45,7 @@ export const defaultSettings = {
   EPCISDocumentSchemaVersion: '2.0',
   documentValidation: true,
   validationMode: 'full',
-  checkExtensions: true,
+  checkExtensions: false,
 };
 
 // Initialize settings with defaults.

--- a/test/data/EPCISDocument-ObjectEvent.json
+++ b/test/data/EPCISDocument-ObjectEvent.json
@@ -1,5 +1,6 @@
 {
   "type": "EPCISDocument",
+  "id":"test:documentId",
   "schemaVersion": "2.0",
   "creationDate": "2013-06-04T14:59:02.099+02:00",
   "sender": "urn:epc:id:sgln:0353579.00001.0",

--- a/test/data/EPCISDocument-ObjectEvent.json
+++ b/test/data/EPCISDocument-ObjectEvent.json
@@ -256,6 +256,10 @@
     },
     {
       "ext1": "http://example.com/ext1/"
+    },
+    {
+      "cbvmda": "http://example.com/cbvmda/",
+      "example": "http://example.com/example/"
     }
   ]
 }

--- a/test/data/EPCISDocument-TransactionEvent.json
+++ b/test/data/EPCISDocument-TransactionEvent.json
@@ -212,7 +212,8 @@
       "ext2": "http://example.com/ext2/"
     },
     {
-      "ext1": "http://example.com/ext1/"
+      "ext1": "http://example.com/ext1/",
+      "example": "http://example.com/example/"
     }
   ]
 }

--- a/test/data/EPCISDocument-TransformationEvent.json
+++ b/test/data/EPCISDocument-TransformationEvent.json
@@ -281,7 +281,9 @@
       "ext2": "http://example.com/ext2/"
     },
     {
-      "ext1": "http://example.com/ext1/"
+      "ext1": "http://example.com/ext1/",
+      "example": "http://example.com/example/",
+      "cbvmda": "http://example.com/cbvmda/"
     }
   ]
 }

--- a/test/data/eventExample.js
+++ b/test/data/eventExample.js
@@ -647,8 +647,8 @@ export const exampleEPCISHeader = {
  * Example of an Extended-Event
  */
 export const extendedEvent = {
-  type: 'ABC_Event',
-  eventID: '_eventID',
+  type: 'ABC:Event',
+  eventID: 'uri:_eventID',
   eventTime: '2013-06-08T14:58:56.591Z',
   eventTimeZoneOffset: '+02:00',
   'ext1:float': '20',

--- a/test/epcis/EPCISDocument.spec.js
+++ b/test/epcis/EPCISDocument.spec.js
@@ -102,6 +102,11 @@ describe('unit tests for the EPCISDocument class', () => {
     expect(e.toObject().epcisBody.eventList).to.deep.equal([o.toObject()]);
   });
 
+  it('should set the id correctly', async () => {
+    const e = new EPCISDocument().setId('test:documentId');
+    expect(e.getId()).to.be.equal('test:documentId');
+  });
+
   it('should not validate the document', async () => {
     const e = new EPCISDocument();
     assert.throws(() => e.isValid());
@@ -384,7 +389,8 @@ describe('unit tests for the EPCISDocument class', () => {
       .setInstanceIdentifier(o.instanceIdentifier)
       .setSender(o.sender)
       .setReceiver(o.receiver)
-      .addEvent(ev);
+      .addEvent(ev)
+      .setId(o.id);
 
     expect(e.toObject()).to.deep.equal(EPCISDocumentObjectEvent);
     expect(e.isValid()).to.be.equal(true);
@@ -488,6 +494,7 @@ describe('unit tests for the EPCISDocument class', () => {
       assert.throws(() => epcisDocument.setInstanceIdentifier(1));
       assert.throws(() => epcisDocument.setReceiver(1));
       assert.throws(() => epcisDocument.setSender(1));
+      assert.throws(() => epcisDocument.setId(1));
     });
     it('setters from EPCISHeader.js', () => {
       const epcisHeader = new EPCISHeader();

--- a/test/events/extendedEvent.spec.js
+++ b/test/events/extendedEvent.spec.js
@@ -175,5 +175,10 @@ describe('unit tests for the ExtendedEvent class', () => {
       const ee = new ExtendedEvent({});
       assert.throw(() => ee.isValid());
     });
+    it('should accept a valid extended event', async () => {
+      const ee = new ExtendedEvent(extendedEvent);
+      ee.isValid()
+      assert.doesNotThrow(() => ee.isValid());
+    });
   });
 });

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -19,7 +19,7 @@ describe('unit tests for setup.js', () => {
       }.toString(),
     );
     expect(settings.validationMode).to.be.equal('full');
-    expect(settings.checkExtensions).to.be.equal(true);
+    expect(settings.checkExtensions).to.be.equal(false);
   });
 
   it('should use custom settings', async () => {

--- a/test/setup.spec.js
+++ b/test/setup.spec.js
@@ -19,6 +19,7 @@ describe('unit tests for setup.js', () => {
       }.toString(),
     );
     expect(settings.validationMode).to.be.equal('full');
+    expect(settings.checkExtensions).to.be.equal(true);
   });
 
   it('should use custom settings', async () => {

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -1292,7 +1292,6 @@ describe('Unit test: validator.js', () => {
     let res = {};
     assert.throws(() => { validateEpcisDocument(epcisDocument); });
     assert.doesNotThrow(() => { res = validateEpcisDocument(epcisDocument, false); });
-    console.log(res);
     expect(res.success).to.be.equal(false);
     expect(res.errors).to.deep.equal(['Event contains unknown extension: example']);
   });

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -44,7 +44,6 @@ const testData = {
 describe('validation of an EPCIS document', () => {
   describe('schema validation: valid', () => {
     it('should accept a valid EPCISDocument containing ObjectEvent', () => {
-      validateEpcisDocument(testData.ObjectEvent);
       assert.doesNotThrow(() => validateEpcisDocument(testData.ObjectEvent));
     });
 
@@ -1220,7 +1219,7 @@ describe('Unit test: validator.js', () => {
       expect(result.errors).to.deep.equal(['EPCISDocument should be object']);
     });
   });
-  it('should accept a document with extensions that are not defined in the context (e.g. example:*}'
+  it('should reject a document with extensions that are not defined in the context (e.g. example:*}'
    + 'if the settings checkExtensions is set to true', () => {
     setup({ checkExtensions: true });
     const epcisDocument = {
@@ -1300,7 +1299,7 @@ describe('Unit test: validator.js', () => {
     expect(res.success).to.be.equal(false);
     expect(res.errors).to.deep.equal(['Event contains unknown extension: example']);
   });
-  it('should accept a document with an event containing extensions that are not defined in the context (e.g. notInContext:*}'
+  it('should reject a document with an event containing extensions that are not defined in the context (e.g. notInContext:*}'
    + 'if the settings checkExtensions is set to true', () => {
     setup({ checkExtensions: true });
     const epcisDocument = {
@@ -1477,7 +1476,7 @@ describe('Unit test: validator.js', () => {
         },
       ]);
       const authorizedExtensions = getAuthorizedExtensions(doc);
-      expect(authorizedExtensions).to.deep.equal(['default', 'ext3', 'ext2', 'ext1', 'cbvmda']);
+      expect(authorizedExtensions).to.deep.equal(['ext3', 'ext2', 'ext1', 'cbvmda']);
     });
   });
   describe('checkIfExtensionsAreDefinedInTheContext()', () => {

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -12,6 +12,7 @@ import {
   SensorElement,
   TransformationEvent,
 } from '../src';
+import setup from '../src/setup';
 import EPCISDocumentObjectEvent from './data/EPCISDocument-ObjectEvent.json';
 import EPCISDocumentAggregationEvent from './data/EPCISDocument-AggregationEvent.json';
 import EPCISDocumentTransformationEvent from './data/EPCISDocument-TransformationEvent.json';
@@ -1294,5 +1295,85 @@ describe('Unit test: validator.js', () => {
     assert.doesNotThrow(() => { res = validateEpcisDocument(epcisDocument, false); });
     expect(res.success).to.be.equal(false);
     expect(res.errors).to.deep.equal(['Event contains unknown extension: example']);
+  });
+  it('should accept a document with extensions that are not defined in the context (e.g. example:*}' +
+    'if the settings checkExtensions is set to false', () => {
+
+    setup({checkExtensions: false});
+    const epcisDocument = {
+      '@context': [
+        'https://gs1.github.io/EPCIS/epcis-context.jsonld',
+        { evt: 'https://example.com/evt/' },
+      ],
+      type: 'EPCISDocument',
+      schemaVersion: '2.0',
+      creationDate: '2005-07-11T11:30:47.0Z',
+      epcisBody: {
+        eventList: [
+          {
+            eventID: 'test:event:id',
+            type: 'ObjectEvent',
+            action: 'OBSERVE',
+            bizStep: cbv.bizSteps.shipping,
+            disposition: cbv.dispositions.in_transit,
+            epcList: [
+              'urn:epc:id:sgtin:0614141.107346.2017',
+              'urn:epc:id:sgtin:0614141.107346.2018',
+            ],
+            eventTime: '2005-04-03T20:33:31.116-06:00',
+            eventTimeZoneOffset: '-06:00',
+            readPoint: {
+              id: 'urn:epc:id:sgln:0614141.07346.1234',
+              'example:extension': 'factoryId',
+            },
+            bizLocation: {
+              id: 'urn:epc:id:sgln:9529999.99999.0',
+              'evt:factoryId': '8934897894',
+            },
+            bizTransactionList: [
+              {
+                type: cbv.businessTransactionTypes.po,
+                bizTransaction: 'http://transaction.acme.com/po/12345678',
+              },
+            ],
+            sensorElementList: [
+              {
+                'example:furtherEventData': [
+                  { 'example:data1': '123.5' },
+                  { 'example:data2': '0.987' },
+                ],
+                sensorMetadata: { time: '2019-04-02T14:55:00.000+01:00' },
+                sensorReport: [
+                  {
+                    type: cbv.sensorMeasurementTypes.temperature,
+                    value: 26.0,
+                    uom: 'CEL',
+                    deviceID: 'urn:epc:id:giai:4000001.111',
+                    deviceMetadata: 'https://id.gs1.org/giai/4000001111',
+                    rawData: 'https://example.org/giai/401234599999',
+                  },
+                  {
+                    type: cbv.sensorMeasurementTypes.relative_humidity,
+                    value: 12.1,
+                    uom: 'A93',
+                    deviceID: 'urn:epc:id:giai:4000001.222',
+                    deviceMetadata: 'https://id.gs1.org/giai/4000001222',
+                    rawData: 'https://example.org/giai/401234599999',
+                  },
+                ],
+              },
+            ],
+            'example:furtherEventData': [
+              { 'example:data1': '123.5' },
+              { 'example:data2': '0.987' },
+            ],
+          },
+        ],
+      },
+    };
+    let res = {};
+    assert.doesNotThrow(() => { res = validateEpcisDocument(epcisDocument, false); });
+    expect(res.success).to.be.equal(true);
+    expect(res.errors).to.deep.equal([]);
   });
 });


### PR DESCRIPTION
# New Features

### New settings
- `checkExtensions` if true, the extension of the EPCISDocument will be checked against the EPCIS Document context. Otherwise, the extensions checks will be ignored.

### Schema(s) validation
- If you set the settings `checkExtensions` to `true` the validation function EPCISDocument.isValid() will check if all the extensions are in the context before validating

### EPCISDocument.id
- The SDK handles the use of the id field for an EPCIS Document

# Other changes

### Examples
- add missing fields in the example with a full combination of fields