### PR TITLE
corrected polarity of default timezone offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import * as epcis from 'epcis2.js';
 
 Or use a simple script tag to load it from the CDN:
 ```html
-<script src="https://cdn.jsdelivr.net/npm/epcis2.js@2.4.0/dist/epcis2.browser.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/epcis2.js@2.4.1/dist/epcis2.browser.js"></script>
 ```
 
 Then use in a browser `script` tag using the `epcis2` global variable:

--- a/example/web-example/index.html
+++ b/example/web-example/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>EPCIS2.js demo</title>
-  <script src="https://cdn.jsdelivr.net/npm/epcis2.js@2.4.0/dist/epcis2.browser.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/epcis2.js@2.4.1/dist/epcis2.browser.js" defer></script>
   <script>
     window.onload = () => {
       const doc = new epcis2.EPCISDocument();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "epcis2.js",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epcis2.js",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Javascript SDK for the EPCIS 2.0 standard",
   "main": "dist/epcis2.node.js",
   "scripts": {

--- a/src/entity/events/Event.js
+++ b/src/entity/events/Event.js
@@ -113,7 +113,7 @@ export default class Event extends Entity {
       this.setEventTimeZoneOffset(settings.eventTimeZoneOffset);
     } else if (!this.eventTimeZoneOffset) {
       const date = new Date();
-      const timeZoneOffset = getTimeZoneOffset(date.getTimezoneOffset() / 60);
+      const timeZoneOffset = getTimeZoneOffset(-(date.getTimezoneOffset()) / 60);
       this.setEventTimeZoneOffset(timeZoneOffset);
     }
 

--- a/test/events/objectEvent.spec.js
+++ b/test/events/objectEvent.spec.js
@@ -43,7 +43,7 @@ describe('unit tests for the ObjectEvent class', () => {
       setup({});
       const o = new ObjectEvent();
       expect(o.eventTimeZoneOffset).to.be.equal(
-        getTimeZoneOffset(new Date().getTimezoneOffset() / 60),
+        getTimeZoneOffset(-(new Date().getTimezoneOffset()) / 60),
       );
     });
 


### PR DESCRIPTION
The calculation of default timeZoneOffsets currently returns `+` when it should be `-` and vice-versa.  This is because [.getTimezoneOffset()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset) returns a positive value for negative timezones and vice-versa.

Changing:
`const timeZoneOffset = getTimeZoneOffset(date.getTimezoneOffset() / 60);`
to:
`const timeZoneOffset = getTimeZoneOffset(-(date.getTimezoneOffset()) / 60);`
accounts for this reversal.

This corrects three scenarios:
***
 * IF eventTime is not provided
 * AND eventTimeZoneOffset is not provided
 * THEN eventTime gets timeZone calculcated and appended with the wrong polarity
 * AND eventTimeZoneOffset gets calculated with the wrong polarity
```
  objectEvent
    // .setEventTime("2022-09-28T10:11:49Z")
    // .setEventTimeZoneOffset("+08:00")

    // In my time zone (-07:00) yields:
    // "eventTimeZoneOffset": "+07:00",
    // "eventTime": "2022-10-10T15:14:11.154+07:00",
```
***
 * IF eventTime is not provided
 * AND eventTimeZoneOffset is provided
 * THEN eventTime gets the timeZone calculated and appended with the wrong polarity
```
  objectEvent
    // .setEventTime("2022-09-28T10:11:49Z")
   .setEventTimeZoneOffset("+08:00")

    // In my time zone (-07:00) yields:
    // "eventTimeZoneOffset": "+08:00",
    // "eventTime": "2022-10-10T15:17:53.852+07:00",
```
***
 * IF eventTime is provided with "Z" suffix
 * AND eventTimeZoneOffset is not provided
 * THEN eventTimeZoneOffset is calculated with the wrong polarity
```
  objectEvent
    .setEventTime("2022-09-28T10:11:49Z")
    // .setEventTimeZoneOffset("+08:00")

    // In my time zone (-07:00) yields:
    // "eventTimeZoneOffset": "+07:00",
    // "eventTime": "2022-09-28T10:11:49Z",
```

