### PR TITLE
Capture namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ import * as epcis from 'epcis2.js';
 
 Or use a simple script tag to load it from the CDN:
 ```html
-<script src="https://cdn.jsdelivr.net/npm/epcis2.js@2.5.0/dist/epcis2.browser.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/epcis2.js@2.6.0/dist/epcis2.browser.js"></script>
 ```
 
 Then use in a browser `script` tag using the `epcis2` global variable:

--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ const epcisDocument = new EPCISDocument({
 To add an event to an EPCIS document, you can use the following:
 
 ```js
+const {
+  ObjectEvent,
+  EPCISDocument,
+  cbv
+} = require('epcis2.js');
+
 const event = new ObjectEvent();
 const event2 = new ObjectEvent();
 const epcisDocument = new EPCISDocument();

--- a/example/node_example/example_with_full_possibility.js
+++ b/example/node_example/example_with_full_possibility.js
@@ -496,6 +496,7 @@ const sendACaptureRequestExample = async () => {
     .setReceiver('urn:epc:id:sgln:5012345.00001.0')
     .setId('test:documentId' + Math.floor(Math.random() * 9))
     .setInstanceIdentifier('1234567890')
+    .addExtension('owl:sameAs', 'ADD')
     .setEPCISHeader(buildEPCISHeaderExample())
     .addEvent(buildAssociationEvent())
     .addEvent(buildObjectEvent())

--- a/example/web-example/index.html
+++ b/example/web-example/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>EPCIS2.js demo</title>
-  <script src="https://cdn.jsdelivr.net/npm/epcis2.js@2.5.0/dist/epcis2.browser.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/epcis2.js@2.6.0/dist/epcis2.browser.js" defer></script>
   <script>
     window.onload = () => {
       const doc = new epcis2.EPCISDocument();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "epcis2.js",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "epcis2.js",
-  "version": "3.0.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epcis2.js",
-  "version": "3.0.0",
+  "version": "2.6.0",
   "description": "Javascript SDK for the EPCIS 2.0 standard",
   "main": "./dist/epcis2.node.js",
   "browser": "./dist/epcis2.browser.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epcis2.js",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "Javascript SDK for the EPCIS 2.0 standard",
   "main": "./dist/epcis2.node.js",
   "browser": "./dist/epcis2.browser.js",

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -17,6 +17,17 @@ import TransactionEvent from './TransactionEvent.schema.json';
 import AssociationEvent from './AssociationEvent.schema.json';
 import ExtendedEvent from './ExtendedEvent.schema.json';
 
+const defaultContext = [
+  "epcis",
+  "cbv",
+  "cbvmda",
+  "gs1",
+  "rdfs",
+  "owl",
+  "xsd",
+  "dcterms",
+]
+
 /**
  * @typedef {object} ValidatorResult
  * @property {boolean} success - true if the validator found no errors.
@@ -50,9 +61,9 @@ export const getAuthorizedExtensions = (epcisDocument) => {
     } else if (epcisDocumentContext instanceof Object) {
       contextObject = epcisDocumentContext;
     }
-    return Object.keys(contextObject);
+    return [...defaultContext, ...Object.keys(contextObject)];
   }
-  return [];
+  return [...defaultContext];
 };
 
 /**

--- a/src/schema/validator.js
+++ b/src/schema/validator.js
@@ -18,15 +18,15 @@ import AssociationEvent from './AssociationEvent.schema.json';
 import ExtendedEvent from './ExtendedEvent.schema.json';
 
 const defaultContext = [
-  "epcis",
-  "cbv",
-  "cbvmda",
-  "gs1",
-  "rdfs",
-  "owl",
-  "xsd",
-  "dcterms",
-]
+  'epcis',
+  'cbv',
+  'cbvmda',
+  'gs1',
+  'rdfs',
+  'owl',
+  'xsd',
+  'dcterms',
+];
 
 /**
  * @typedef {object} ValidatorResult

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -1524,7 +1524,7 @@ describe('Unit test: validator.js', () => {
           },
         ],
       },
-      "owl:sameAs": "above"
+      'owl:sameAs': 'above',
     };
     let res = {};
     assert.doesNotThrow(() => { res = validateEpcisDocument(epcisDocument, false); });
@@ -1587,7 +1587,7 @@ describe('Unit test: validator.js', () => {
         'https://ref.gs1.org/standards/epcis/2.0.0/epcis-context.jsonld',
         {
           ext: 'http://example.com/ext/',
-        }
+        },
       ]);
       const authorizedExtensions = getAuthorizedExtensions(doc);
       expect(checkIfExtensionsAreDefinedInTheContext(['ext', 'cbvmda', 'gs1', 'rdfs', 'owl', 'xsd', 'dcterms'], authorizedExtensions)).to.deep.equal(

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -1182,6 +1182,7 @@ describe('Unit test: validator.js', () => {
       assert.throws(() => { te.isValid(); });
     });
   });
+
   describe('schema validation: throwError = false', () => {
     it('should accept a valid EPCISDocument containing ObjectEvent', () => {
       const instance = { ...testData.ObjectEvent };
@@ -1191,6 +1192,7 @@ describe('Unit test: validator.js', () => {
       expect(result.success).to.be.equal(true);
       expect(result.errors).to.deep.equal([]);
     });
+
     it('should reject a valid EPCISDocument containing an invalid AssociationEvent', () => {
       const instance = { ...testData.AssociationEvent };
 
@@ -1202,12 +1204,14 @@ describe('Unit test: validator.js', () => {
       expect(result.success).to.be.equal(false);
       expect(result.errors).to.deep.equal(['EPCISDocument/epcisBody/eventList/0/action should be equal to one of the allowed values']);
     });
+
     it('should reject a null EPCISDocument ', () => {
       let result = {};
       assert.doesNotThrow(() => { result = validateEpcisDocument(null, false); });
       expect(result.success).to.be.equal(false);
       expect(result.errors).to.deep.equal(['EPCISDocument should be object']);
     });
+
     it('should reject an undefined EPCISDocument ', () => {
       let result = {};
       assert.doesNotThrow(() => { result = validateEpcisDocument(undefined, false); });
@@ -1215,6 +1219,7 @@ describe('Unit test: validator.js', () => {
       expect(result.errors).to.deep.equal(['EPCISDocument should be object']);
     });
   });
+
   it('should reject a document with extensions that are not defined in the context (e.g. example:*}'
    + 'if the settings checkExtensions is set to true', () => {
     setup({ checkExtensions: true });
@@ -1295,6 +1300,7 @@ describe('Unit test: validator.js', () => {
     expect(res.success).to.be.equal(false);
     expect(res.errors).to.deep.equal(['Event contains unknown extension: example']);
   });
+
   it('should reject a document with an event containing extensions that are not defined in the context (e.g. notInContext:*}'
    + 'if the settings checkExtensions is set to true', () => {
     setup({ checkExtensions: true });
@@ -1376,6 +1382,7 @@ describe('Unit test: validator.js', () => {
     expect(res.success).to.be.equal(false);
     expect(res.errors).to.deep.equal(['Event contains unknown extension: notInContext']);
   });
+
   it('should accept a document with extensions that are not defined in the context (e.g. example:*}' +
     'if the settings checkExtensions is set to false', () => {
     setup({ checkExtensions: false });
@@ -1455,6 +1462,76 @@ describe('Unit test: validator.js', () => {
     expect(res.success).to.be.equal(true);
     expect(res.errors).to.deep.equal([]);
   });
+
+  it('should accept a document with extensions that are defined in the default EPCIS context', () => {
+    setup({ checkExtensions: true });
+    const epcisDocument = {
+      '@context': [
+        'https://ref.gs1.org/standards/epcis/2.0.0/epcis-context.jsonld',
+      ],
+      type: 'EPCISDocument',
+      schemaVersion: '2.0',
+      creationDate: '2005-07-11T11:30:47.0Z',
+      epcisBody: {
+        eventList: [
+          {
+            eventID: 'test:event:id',
+            type: 'ObjectEvent',
+            action: 'OBSERVE',
+            bizStep: cbv.bizSteps.shipping,
+            disposition: cbv.dispositions.in_transit,
+            epcList: [
+              'urn:epc:id:sgtin:0614141.107346.2017',
+              'urn:epc:id:sgtin:0614141.107346.2018',
+            ],
+            eventTime: '2005-04-03T20:33:31.116-06:00',
+            eventTimeZoneOffset: '-06:00',
+            readPoint: {
+              id: 'urn:epc:id:sgln:0614141.07346.1234',
+            },
+            bizLocation: {
+              id: 'urn:epc:id:sgln:9529999.99999.0',
+            },
+            bizTransactionList: [
+              {
+                type: cbv.businessTransactionTypes.po,
+                bizTransaction: 'http://transaction.acme.com/po/12345678',
+              },
+            ],
+            sensorElementList: [
+              {
+                sensorMetadata: { time: '2019-04-02T14:55:00.000+01:00' },
+                sensorReport: [
+                  {
+                    type: cbv.sensorMeasurementTypes.temperature,
+                    value: 26.0,
+                    uom: 'CEL',
+                    deviceID: 'urn:epc:id:giai:4000001.111',
+                    deviceMetadata: 'https://id.gs1.org/giai/4000001111',
+                    rawData: 'https://example.org/giai/401234599999',
+                  },
+                  {
+                    type: cbv.sensorMeasurementTypes.relative_humidity,
+                    value: 12.1,
+                    uom: 'A93',
+                    deviceID: 'urn:epc:id:giai:4000001.222',
+                    deviceMetadata: 'https://id.gs1.org/giai/4000001222',
+                    rawData: 'https://example.org/giai/401234599999',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "owl:sameAs": "above"
+    };
+    let res = {};
+    assert.doesNotThrow(() => { res = validateEpcisDocument(epcisDocument, false); });
+    expect(res.success).to.be.equal(true);
+    expect(res.errors).to.deep.equal([]);
+  });
+
   describe('getAuthorizedExtensions()', () => {
     it('should return the list of authorized extensions', () => {
       const doc = new EPCISDocument();
@@ -1472,9 +1549,13 @@ describe('Unit test: validator.js', () => {
         },
       ]);
       const authorizedExtensions = getAuthorizedExtensions(doc);
-      expect(authorizedExtensions).to.deep.equal(['ext3', 'ext2', 'ext1', 'cbvmda']);
+      expect(authorizedExtensions).to.include('cbvmda');
+      expect(authorizedExtensions).to.include('ext1');
+      expect(authorizedExtensions).to.include('ext2');
+      expect(authorizedExtensions).to.include('ext3');
     });
   });
+
   describe('checkIfExtensionsAreDefinedInTheContext()', () => {
     it('should return true if all extensions are defined in the context', () => {
       const doc = new EPCISDocument();
@@ -1492,13 +1573,31 @@ describe('Unit test: validator.js', () => {
         },
       ]);
       const authorizedExtensions = getAuthorizedExtensions(doc);
-      expect(checkIfExtensionsAreDefinedInTheContext(['ext1', 'cbvmda', 'ext3', 'ext3'], authorizedExtensions)).to.deep.equal(
+      expect(checkIfExtensionsAreDefinedInTheContext(['ext1', 'cbvmda', 'ext2', 'ext3'], authorizedExtensions)).to.deep.equal(
         {
           success: true,
           errors: [],
         },
       );
     });
+
+    it('should return true if extensions are defined in the default epcis context', () => {
+      const doc = new EPCISDocument();
+      doc.setContext([
+        'https://ref.gs1.org/standards/epcis/2.0.0/epcis-context.jsonld',
+        {
+          ext: 'http://example.com/ext/',
+        }
+      ]);
+      const authorizedExtensions = getAuthorizedExtensions(doc);
+      expect(checkIfExtensionsAreDefinedInTheContext(['ext', 'cbvmda', 'gs1', 'rdfs', 'owl', 'xsd', 'dcterms'], authorizedExtensions)).to.deep.equal(
+        {
+          success: true,
+          errors: [],
+        },
+      );
+    });
+
     it('should return false if some extensions are not defined in the context', () => {
       const doc = new EPCISDocument();
       doc.setContext([


### PR DESCRIPTION
# Breaking change

The validator now accepts by default extensions with namespaces defined in the default context. (e.g cbvmda, rdfs, ...)