### PR TITLE
Added Typescript defs; need to integrate w/NPM publish.

### DIFF
--- a/example/node_example/package-lock.json
+++ b/example/node_example/package-lock.json
@@ -7,10 +7,13 @@
     "epcis2.js": {
       "version": "file:../..",
       "requires": {
+        "@types/node": "^18.11.18",
         "ajv": "^7.1.0",
         "ajv-formats": "^1.5.1",
         "cross-fetch": "^3.1.4",
         "crypto-js": "^3.3.0",
+        "digital-link.js": "^1.3.0",
+        "epc-tds": "^1.3.0",
         "fs": "0.0.1-security",
         "is-plain-object": "^5.0.0",
         "querystring": "^0.2.1",
@@ -279,6 +282,16 @@
             "to-fast-properties": "^2.0.0"
           }
         },
+        "@ollah666/checkdigitcalculator": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@ollah666/checkdigitcalculator/-/checkdigitcalculator-1.0.4.tgz",
+          "integrity": "sha512-textWLuhqZ5Z88WBX0xkE9pxX5zWK31gbM7H3VFMlJowMdME4OFBvgpzOR+B1cKgtq4/zGyDczUou8jf1e2B7w=="
+        },
+        "@types/node": {
+          "version": "18.11.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+          "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+        },
         "ajv": {
           "version": "7.2.4",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
@@ -322,6 +335,19 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "^1.9.0"
+          }
+        },
+        "apg-conv-api": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/apg-conv-api/-/apg-conv-api-1.0.1.tgz",
+          "integrity": "sha512-1h4LB3N/4+FcujMGQIp0OIKdNNlwyXF8e4duy6ACjBUdHSUT4z5PVyFaf9+ego52IpgNAAdQCl6Up9vTM9cvqg=="
+        },
+        "apg-lib": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/apg-lib/-/apg-lib-3.2.0.tgz",
+          "integrity": "sha512-igSp4Zoq47Brp9B2mKXXE7tleC+bLWgMTgYSGCb5UIs3w+xz/qwCh2drtp7kyRtTN6GFcAwD3pXtqwtdfg+EHw==",
+          "requires": {
+            "apg-conv-api": "1.0.x"
           }
         },
         "asynckit": {
@@ -465,10 +491,24 @@
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
+        "digital-link.js": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/digital-link.js/-/digital-link.js-1.3.0.tgz",
+          "integrity": "sha512-2PflsPQpHsd7lvnVPgpvCVYRo3+Xlysxnn3QgWdcZ0XYiCdbb8PvHPrLB8wqv2QjD1/RlkL+Bj9uRpYEv8vq3Q==",
+          "requires": {
+            "@ollah666/checkdigitcalculator": "^1.0.4",
+            "apg-lib": "^3.2.0"
+          }
+        },
         "electron-to-chromium": {
           "version": "1.4.84",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.84.tgz",
           "integrity": "sha512-b+DdcyOiZtLXHdgEG8lncYJdxbdJWJvclPNMg0eLUDcSOSO876WA/pYjdSblUTd7eJdIs4YdIxHWGazx7UPSJw=="
+        },
+        "epc-tds": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/epc-tds/-/epc-tds-1.3.0.tgz",
+          "integrity": "sha512-n/o0++ehkHdNVb0iqb5AWT/QB8kC5x3YJUMiURuDzKwRRR6Mw8Xh29EJopz2Lrqbu4tXI3sbvGuYCxGkZQjzUQ=="
         },
         "escalade": {
           "version": "3.1.1",

--- a/example/node_example/package.json
+++ b/example/node_example/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "main": "example_with_creation_from_setters.js",
   "license": "Apache-2.0",
+  "scripts": {
+    "typescriptExample": "cd typescript; tsc; node dist/typescript_example.js"
+  },
   "dependencies": {
     "epcis2.js": "file:../../"
   }

--- a/example/node_example/typescript/tsconfig.json
+++ b/example/node_example/typescript/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "include": ["*"],
+  "compilerOptions": {
+    "target": "ESNEXT",
+    "module": "commonjs",
+    "allowJs": true,
+    "declaration": true,
+    "outDir": "./dist"
+  }
+}

--- a/example/node_example/typescript/typescript_example.ts
+++ b/example/node_example/typescript/typescript_example.ts
@@ -1,0 +1,59 @@
+/**
+ * (c) Copyright Reserved EVRYTHNG Limited 2021. All rights reserved.
+ * Use of this material is subject to license.
+ * Copying and unauthorised use of this material strictly prohibited.
+ */
+
+/* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+
+import {
+  ObjectEvent,
+  cbv,
+  setup,
+  EPCISDocument,
+  capture,
+  BizTransactionElement,
+} from 'epcis2.js';
+
+// you can override the global parameter with the setup function
+setup({
+  apiUrl: 'https://api.evrythng.io/v2/epcis/',
+  EPCISDocumentContext: 'https://ref.gs1.org/standards/epcis/2.0.0/epcis-context.jsonld',
+  EPCISDocumentSchemaVersion: '2.0',
+  headers: {
+    'content-type': 'application/json',
+    authorization: 'MY_API_KEY',
+  },
+});
+
+const sendACaptureRequestExample = async (): Promise<void> => {
+  const objectEvent: ObjectEvent = new ObjectEvent();
+  const epcisDocument: EPCISDocument = new EPCISDocument();
+  const bizTransaction: BizTransactionElement = new BizTransactionElement({
+    type: 'po',
+    bizTransaction: 'http://transaction.acme.com/po/12345678',
+  });
+
+  objectEvent
+    .setEventTime('2005-04-03T20:33:31.116-06:00')
+    .addEPC('urn:epc:id:sgtin:0614141.107346.2020')
+    .addEPC('urn:epc:id:sgtin:0614141.107346.2021')
+    .setAction(cbv.actionTypes.observe)
+    .setEventID('ni:///sha-256;87b5f18a69993f0052046d4687dfacdf48f?ver=CBV2.0')
+    .setBizStep(cbv.bizSteps.shipping)
+    .setDisposition(cbv.dispositions.in_transit)
+    .setReadPoint('urn:epc:id:sgln:0614141.07346.1234')
+    .addBizTransaction(bizTransaction);
+
+  epcisDocument.setCreationDate('2005-07-11T11:30:47+00:00').addEvent(objectEvent);
+
+  console.log(`BizStep of the object event: ${objectEvent.getBizStep()}`);
+  console.log(`Action of the object event: ${objectEvent.getAction()}`);
+  console.log('objectEvent: ');
+  console.log(objectEvent.toObject());
+  console.log(`epcisDocument (toString): ${epcisDocument.toString()}`);
+};
+
+sendACaptureRequestExample();
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1453,10 +1453,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
-      "dev": true
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -6113,6 +6112,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "lint": "eslint --fix --max-warnings 0 --ext .js .",
     "format": "./node_modules/.bin/prettier --write '**/*.{js,json,md,yaml,yml}'",
-    "build": "rm dist/*; tsc; webpack --config webpack.config.js --mode production",
-    "build:dev": "rm dist/*; tsc; webpack --config webpack.config.js --mode development",
+    "build": "rm -r dist/*; tsc; webpack --config webpack.config.js --mode production",
+    "build:dev": "rm -r dist/*; tsc; webpack --config webpack.config.js --mode development",
     "test": "nyc ./node_modules/mocha/bin/mocha --require @babel/polyfill --require @babel/register './test/**/*.spec.js'",
     "prepublishOnly": "npm run build && npm test"
   },
@@ -78,6 +78,7 @@
     "wnpm-ci": "^7.0.100"
   },
   "dependencies": {
+    "@types/node": "^18.11.18",
     "ajv": "^7.1.0",
     "ajv-formats": "^1.5.1",
     "cross-fetch": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "lint": "eslint --fix --max-warnings 0 --ext .js .",
     "format": "./node_modules/.bin/prettier --write '**/*.{js,json,md,yaml,yml}'",
-    "build": "rm dist/*; webpack --config webpack.config.js --mode production",
-    "build:dev": "rm dist/*; webpack --config webpack.config.js --mode development",
+    "build": "rm dist/*; tsc; webpack --config webpack.config.js --mode production",
+    "build:dev": "rm dist/*; tsc; webpack --config webpack.config.js --mode development",
     "test": "nyc ./node_modules/mocha/bin/mocha --require @babel/polyfill --require @babel/register './test/**/*.spec.js'",
     "prepublishOnly": "npm run build && npm test"
   },
@@ -72,6 +72,7 @@
     "mocha": "^9.2.1",
     "nyc": "^15.1.0",
     "prettier": "^2.2.1",
+    "typescript": "^4.9.4",
     "webpack": "^5.30.0",
     "webpack-cli": "^4.6.0",
     "wnpm-ci": "^7.0.100"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "target": "ESNEXT",
+    "module": "commonjs", 
+    "allowJs": true,
+    "declaration": true,
+    "outDir": "./dist"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,31 @@
     "module": "commonjs", 
     "allowJs": true,
     "declaration": true,
-    "outDir": "./dist"
+
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    // * To bundle typescript defs w/javascript files:
+    // *
+    // * Set outDir to ./dist folder. This will place the .d.ts definition 
+    // * files alongside the .js files in the ./dist folder.
+    // *
+    // * Then publish the contents of the ./dist folder as your NPM module.
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    //"outDir": "./dist"
+
+
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    // * To publish typescript defs separately from the javascript code files:
+    // *
+    // * Set outDir to ./@types/epcis2.js folder and set emitDeclarationsOnly
+    // * to true. This will put the .d.ts definitionfiles in a separate 
+    // * folder for publication to the @types organization on NPM 
+    // * (https://www.npmjs.com/~types).
+    // * 
+    // * This approach will allow you to publish the source javascript files, 
+    // * (from the ./src folder), as your NPM module as you currently do while
+    // * providing the type definitions for TS developers if they need them.
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+    "emitDeclarationOnly": true,
+    "outDir": "./@types/epcis2.js"
   }
 }


### PR DESCRIPTION
Hey Guys -- 

I'd like to add Typescript support. I've added a tsconfig.json file and added the compile step to the package.json. The d.ts definitions are now published with the .js files in the ./dist folder. Still need to include them with the NPM package, but not sure how you'd like to handle that, (bundled/publish to @types).

Let me know your thoughts...

Scott --